### PR TITLE
Show the countdown in the bar, behind a toggle in the popup

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -50,6 +50,36 @@ BarWidget {
     ? (location ? location + " · " : "") + nextPrayer.name + " in " + Model.timeRemaining(nextPrayer, nowTick) + " (" + Model.formatTime12(nextPrayer.time) + ")"
     : "Prayer times"
 
+  // Countdown beside the icon. Off by default: this widget is built to sit
+  // among the wifi/sound icons, and a label changes how much of the bar it
+  // claims, so that is the user's call rather than ours. Flipped by the
+  // toggle at the bottom of the popup, stored with the alert preferences.
+  property bool showCountdown: false
+
+  // The same countdown the tooltip spells out, trimmed to what fits in a bar
+  // slot ("Asr 1h 4m"). Empty until the first fetch lands, so the icon stands
+  // alone rather than the bar holding width for a placeholder.
+  readonly property string countdownText: Model.countdownLabel(nextPrayer, nowTick)
+
+  // A vertical bar has no room for a label, so there the countdown stays in
+  // the tooltip whatever the setting says.
+  readonly property bool countdownVisible: showCountdown && !vertical && countdownText !== ""
+
+  // Minutes left at which the label takes the urgent accent -- the same colour
+  // the popup already gives the next prayer, so the bar and the list agree on
+  // what is imminent.
+  readonly property int urgentMinutes: 10
+  readonly property bool countdownUrgent: {
+    var left = Model.minutesRemaining(nextPrayer, nowTick)
+    return left >= 0 && left <= urgentMinutes
+  }
+
+  // With the label on, this module is a text row in a padded slot, so the
+  // open-panel mark tracks what it paints instead of a fraction of the slot it
+  // fills -- the same hint the built-in clock gives. Icon-only, the bar's
+  // default mark is already right.
+  readonly property real openPanelIndicatorWidth: countdownVisible ? content.implicitWidth : 0
+
   function refresh() {
     if (!fetchProc.running) fetchProc.running = true
   }
@@ -130,6 +160,7 @@ BarWidget {
     var settings = Model.parseSettings(raw)
     root.alertsEnabled = settings.alerts
     root.soundEnabled = settings.sound
+    root.showCountdown = settings.countdown
     root.settingsLoaded = true
   }
 
@@ -139,9 +170,10 @@ BarWidget {
     // lands after it.
     root.settingsLoaded = true
     settingsFile.setText(JSON.stringify({
-      version: 2,
+      version: 3,
       alerts: root.alertsEnabled,
-      sound: root.soundEnabled
+      sound: root.soundEnabled,
+      countdown: root.showCountdown
     }, null, 2) + "\n")
   }
 
@@ -285,15 +317,62 @@ BarWidget {
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
-  BarIconButton {
+  // Icon, plus the countdown when it is switched on. Laid out the way the
+  // built-in media widget does it: a Row paints the content inside a
+  // WidgetButton whose own label is off, so the button still supplies the
+  // bar's tooltip, click registration and hover handling while the width
+  // follows the text. With the label hidden the slot is the same icon slot
+  // BarIconButton was giving.
+  WidgetButton {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: root.iconGlyph
+    labelVisible: false
+    hasVisualContent: true
     tooltipText: root.tooltipLabel
+    fixedWidth: root.vertical
+      ? -1
+      : (root.countdownVisible ? content.implicitWidth + button.scaledHorizontalMargin * 2 : Style.bar.iconSlot)
+    fixedHeight: root.vertical ? Style.bar.iconSlot : -1
+
     onPressed: function(b) {
       if (b === Qt.RightButton || b === Qt.MiddleButton) root.refresh()
       else root.popupOpen = !root.popupOpen
+    }
+
+    Row {
+      id: content
+      anchors.centerIn: parent
+      spacing: Style.space(6)
+
+      // OpticalGlyph rather than a bare Text: it puts the mosque on the same
+      // optical centre as every other icon in the bar.
+      OpticalGlyph {
+        anchors.verticalCenter: parent.verticalCenter
+        width: Style.bar.iconCanvas
+        height: Style.bar.iconCanvas
+        text: root.iconGlyph
+        fontFamily: button.fontFamily
+        fontSize: Style.bar.iconFont
+        color: button.foreground
+      }
+
+      // Hidden rather than blank: Row leaves invisible children out, so the
+      // button shrinks back to the icon slot.
+      Text {
+        anchors.verticalCenter: parent.verticalCenter
+        visible: root.countdownVisible
+        text: root.countdownText
+        color: root.countdownUrgent ? button.activeColor : button.foreground
+        font.family: button.fontFamily
+        font.pixelSize: Style.font.body
+        renderType: Text.NativeRendering
+
+        Behavior on color {
+          enabled: !root.bar || root.bar.foregroundAnimationEnabled
+          ColorAnimation { duration: 160 }
+        }
+      }
     }
   }
 
@@ -529,6 +608,24 @@ BarWidget {
           titleSize: Style.font.bodySmall
           onClicked: {
             root.soundEnabled = !root.soundEnabled
+            root.saveSettings()
+          }
+        }
+
+        // Last of the switches: the only one that changes nothing but how the
+        // bar looks. Hidden on a vertical bar, where there is no room for the
+        // label and the toggle would control nothing.
+        Toggle {
+          visible: !root.vertical
+          width: parent.width
+          label: "Countdown in bar"
+          description: root.showCountdown ? "Next prayer and time left beside the icon" : "Icon only"
+          checked: root.showCountdown
+          foreground: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+          titleSize: Style.font.bodySmall
+          onClicked: {
+            root.showCountdown = !root.showCountdown
             root.saveSettings()
           }
         }

--- a/Model.js
+++ b/Model.js
@@ -57,15 +57,21 @@ function prayerKey(prayer) {
   return d.getFullYear() + "-" + (d.getMonth() + 1) + "-" + d.getDate() + " " + prayer.name
 }
 
-// Alerts preference file -> { alerts, sound }. Anything missing or corrupt
-// reads as enabled, so a first run (or a file we can't parse) still alerts.
-// v1 files carry no `sound` key; they fall through to the default.
+// Widget preference file -> { alerts, sound, countdown }. Anything missing or
+// corrupt reads as its default, so a first run (or a file we can't parse) still
+// alerts. Older files carry fewer keys -- v1 has no `sound`, v2 no `countdown`
+// -- and each falls through.
+//
+// countdown defaults to false: the widget is built to sit among the wifi/sound
+// icons, so the bar label is something the user asks for rather than something
+// an upgrade springs on them.
 function parseSettings(raw) {
-  var out = { alerts: true, sound: true }
+  var out = { alerts: true, sound: true, countdown: false }
   try {
     var data = JSON.parse(String(raw || "{}"))
     if (data && typeof data.alerts === "boolean") out.alerts = data.alerts
     if (data && typeof data.sound === "boolean") out.sound = data.sound
+    if (data && typeof data.countdown === "boolean") out.countdown = data.countdown
   } catch (e) {}
   return out
 }
@@ -92,6 +98,16 @@ function timeRemaining(next, now) {
   var h = Math.floor(totalMin / 60)
   var m = totalMin % 60
   return h > 0 ? (h + "h " + m + "m") : (m + "m")
+}
+
+// Whole minutes until `next`, or -1 when there is nothing to count down to.
+// Rounded the same way as timeRemaining, so the bar label cannot read "10m"
+// while a threshold checked against this still believes there are 11 left.
+function minutesRemaining(next, now) {
+  if (!next || !next.date) return -1
+  var diffMs = next.date.getTime() - now.getTime()
+  if (diffMs <= 0) return 0
+  return Math.round(diffMs / 60000)
 }
 
 function countdownLabel(next, now) {
@@ -148,6 +164,7 @@ if (typeof module !== "undefined") {
     parseSettings: parseSettings,
     formatTime12: formatTime12,
     timeRemaining: timeRemaining,
+    minutesRemaining: minutesRemaining,
     countdownLabel: countdownLabel,
     parseGeocodingResults: parseGeocodingResults,
     locationCommit: locationCommit

--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ until it restarts.
 
 ## Configuration
 
+### Countdown in the bar
+
+Off by default — the icon is meant to sit among the built-in wifi/sound icons,
+and a label changes how much of the bar the widget claims. The **Countdown in
+bar** toggle at the bottom of the popup paints it next to the icon
+(`󰚁 Asr 1h 4m`) instead of only on hover, and is stored in
+`prayer-alerts.json` with the other preferences.
+
+It takes the bar's urgent colour with 10 minutes or less to go — the same
+accent the popup gives the next prayer — and it is left out on a vertical bar,
+where there is no room for it; the tooltip still has it there.
+
+### Calculation method
+
 Calculation method defaults to Muslim World League (Aladhan method `3`).
 Change it by editing `METHOD` in `prayer-fetch.sh`, or override per-run with
 `PRAYER_METHOD=<id>`. See the


### PR DESCRIPTION
The manifest already advertises a *"next prayer countdown"*, and `Model.countdownLabel()` is written and exported for exactly that — but nothing calls it, so the countdown only ever reaches the tooltip. This paints it next to the icon.

```
before   󰚁
after    󰚁  Asr 1h 4m
```

**It is off by default.** The README is explicit that the widget is meant to sit among the built-in wifi/sound icons with no inline text, and a label changes how much of the bar it claims — so it seemed wrong to make that call for everyone. It is opt-in via a **Countdown in bar** switch at the bottom of the popup, alongside the existing ones:

```
Alerts              [ off ]
Sound               [ on  ]
Countdown in bar    [ off ]   ← new
```

It is stored in `prayer-alerts.json` with the other preferences. `parseSettings` gains `countdown`, defaulting false, and v1/v2 files fall through to that default the same way v1 already does for `sound`. With the countdown off the slot is the same width `BarIconButton` was giving, so nothing moves for anyone who does not ask for it.

### How it is built

The layout follows the built-in media widget: a `Row` paints the content inside a `WidgetButton` whose own label is off, so the button still supplies the bar's tooltip, click registration and hover handling while the width follows the text. The icon goes through `OpticalGlyph` so it keeps the same optical centre as every other bar icon.

- Under 10 minutes the label takes `bar.urgent` — the accent the popup already gives the next prayer, so the bar and the list agree on what is imminent.
- A vertical bar has no room for a label, so there it is left out, the countdown stays in the tooltip, and the toggle hides itself rather than controlling nothing.
- `openPanelIndicatorWidth` is reported so the open-panel mark tracks the painted text rather than a fraction of the padded slot, the same hint the built-in clock gives.
- `minutesRemaining()` rounds the same way `timeRemaining()` does, so the label cannot read `10m` while the urgent threshold still sees 11.

### Checks

`omarchy plugin validate` and `qmllint -I $OMARCHY_PATH/shell` both clean. `Model.js` exercised over a normal gap, the sub-10-minute case, the 1-minute case, null timings, the past-Isha rollover to tomorrow's Fajr, and preference files at v1/v2/v3/empty/corrupt. Ran on a live bar in both states — default-off is pixel-identical to before, and the toggle renders and persists.

Happy to change the default, the 10-minute threshold, or the toggle's wording if you would rather have them another way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
