### PR TITLE
Pick the madhhab that sets Asr

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -50,6 +50,36 @@ BarWidget {
     ? (location ? location + " · " : "") + nextPrayer.name + " in " + Model.timeRemaining(nextPrayer, nowTick) + " (" + Model.formatTime12(nextPrayer.time) + ")"
     : "Prayer times"
 
+  // Countdown beside the icon. Off by default: this widget is built to sit
+  // among the wifi/sound icons, and a label changes how much of the bar it
+  // claims, so that is the user's call rather than ours. Flipped by the
+  // toggle at the bottom of the popup, stored with the alert preferences.
+  property bool showCountdown: false
+
+  // The same countdown the tooltip spells out, trimmed to what fits in a bar
+  // slot ("Asr 1h 4m"). Empty until the first fetch lands, so the icon stands
+  // alone rather than the bar holding width for a placeholder.
+  readonly property string countdownText: Model.countdownLabel(nextPrayer, nowTick)
+
+  // A vertical bar has no room for a label, so there the countdown stays in
+  // the tooltip whatever the setting says.
+  readonly property bool countdownVisible: showCountdown && !vertical && countdownText !== ""
+
+  // Minutes left at which the label takes the urgent accent -- the same colour
+  // the popup already gives the next prayer, so the bar and the list agree on
+  // what is imminent.
+  readonly property int urgentMinutes: 10
+  readonly property bool countdownUrgent: {
+    var left = Model.minutesRemaining(nextPrayer, nowTick)
+    return left >= 0 && left <= urgentMinutes
+  }
+
+  // With the label on, this module is a text row in a padded slot, so the
+  // open-panel mark tracks what it paints instead of a fraction of the slot it
+  // fills -- the same hint the built-in clock gives. Icon-only, the bar's
+  // default mark is already right.
+  readonly property real openPanelIndicatorWidth: countdownVisible ? content.implicitWidth : 0
+
   function refresh() {
     if (!fetchProc.running) fetchProc.running = true
   }
@@ -130,6 +160,7 @@ BarWidget {
     var settings = Model.parseSettings(raw)
     root.alertsEnabled = settings.alerts
     root.soundEnabled = settings.sound
+    root.showCountdown = settings.countdown
     root.settingsLoaded = true
   }
 
@@ -139,9 +170,10 @@ BarWidget {
     // lands after it.
     root.settingsLoaded = true
     settingsFile.setText(JSON.stringify({
-      version: 2,
+      version: 3,
       alerts: root.alertsEnabled,
-      sound: root.soundEnabled
+      sound: root.soundEnabled,
+      countdown: root.showCountdown
     }, null, 2) + "\n")
   }
 
@@ -285,15 +317,62 @@ BarWidget {
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
-  BarIconButton {
+  // Icon, plus the countdown when it is switched on. Laid out the way the
+  // built-in media widget does it: a Row paints the content inside a
+  // WidgetButton whose own label is off, so the button still supplies the
+  // bar's tooltip, click registration and hover handling while the width
+  // follows the text. With the label hidden the slot is the same icon slot
+  // BarIconButton was giving.
+  WidgetButton {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: root.iconGlyph
+    labelVisible: false
+    hasVisualContent: true
     tooltipText: root.tooltipLabel
+    fixedWidth: root.vertical
+      ? -1
+      : (root.countdownVisible ? content.implicitWidth + button.scaledHorizontalMargin * 2 : Style.bar.iconSlot)
+    fixedHeight: root.vertical ? Style.bar.iconSlot : -1
+
     onPressed: function(b) {
       if (b === Qt.RightButton || b === Qt.MiddleButton) root.refresh()
       else root.popupOpen = !root.popupOpen
+    }
+
+    Row {
+      id: content
+      anchors.centerIn: parent
+      spacing: Style.space(6)
+
+      // OpticalGlyph rather than a bare Text: it puts the mosque on the same
+      // optical centre as every other icon in the bar.
+      OpticalGlyph {
+        anchors.verticalCenter: parent.verticalCenter
+        width: Style.bar.iconCanvas
+        height: Style.bar.iconCanvas
+        text: root.iconGlyph
+        fontFamily: button.fontFamily
+        fontSize: Style.bar.iconFont
+        color: button.foreground
+      }
+
+      // Hidden rather than blank: Row leaves invisible children out, so the
+      // button shrinks back to the icon slot.
+      Text {
+        anchors.verticalCenter: parent.verticalCenter
+        visible: root.countdownVisible
+        text: root.countdownText
+        color: root.countdownUrgent ? button.activeColor : button.foreground
+        font.family: button.fontFamily
+        font.pixelSize: Style.font.body
+        renderType: Text.NativeRendering
+
+        Behavior on color {
+          enabled: !root.bar || root.bar.foregroundAnimationEnabled
+          ColorAnimation { duration: 160 }
+        }
+      }
     }
   }
 
@@ -529,6 +608,24 @@ BarWidget {
           titleSize: Style.font.bodySmall
           onClicked: {
             root.soundEnabled = !root.soundEnabled
+            root.saveSettings()
+          }
+        }
+
+        // Last of the switches: the only one that changes nothing but how the
+        // bar looks. Hidden on a vertical bar, where there is no room for the
+        // label and the toggle would control nothing.
+        Toggle {
+          visible: !root.vertical
+          width: parent.width
+          label: "Countdown in bar"
+          description: root.showCountdown ? "Next prayer and time left beside the icon" : "Icon only"
+          checked: root.showCountdown
+          foreground: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+          titleSize: Style.font.bodySmall
+          onClicked: {
+            root.showCountdown = !root.showCountdown
             root.saveSettings()
           }
         }

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -16,6 +16,10 @@ BarWidget {
   property var timings: null
   property string location: ""
   property string hijri: ""
+  // Which madhhab the cached timings were actually fetched under, echoed back
+  // by the API. Compared against hanafiAsr so a refetch that failed (offline,
+  // API down) can't leave the popup quietly showing the other school's Asr.
+  property string cachedSchool: ""
   property string lastError: ""
   property bool popupOpen: false
   property date nowTick: new Date()
@@ -33,7 +37,17 @@ BarWidget {
   readonly property string soundPath: "/usr/share/sounds/freedesktop/stereo/bell.oga"
   property bool alertsEnabled: true
   property bool soundEnabled: true
+
+  // Asr per the Hanafi madhhab (shadow twice the object's length) instead of
+  // the standard one (shadow equal to it), which puts Asr roughly an hour
+  // later. The whole timetable is recomputed server-side, so flipping this
+  // has to re-fetch rather than shift the cached time locally.
+  property bool hanafiAsr: false
+
   property bool settingsLoaded: false
+  // A refresh asked for before the preference file had been read, or while a
+  // fetch was already in flight. Drained by markSettingsReady/fetchProc.
+  property bool refetchQueued: false
 
   // Click-to-edit location, same mechanism as the weather widget: persists
   // to the shared weather.json via omarchy-weather-location, so editing the
@@ -46,6 +60,10 @@ BarWidget {
   property string geocodeActiveQuery: ""
 
   readonly property var nextPrayer: Model.nextPrayer(timings, nowTick)
+  // True when the times on screen were fetched under the other madhhab.
+  readonly property bool asrOutOfDate: root.timings !== null && root.cachedSchool !== ""
+    && root.cachedSchool !== (root.hanafiAsr ? "HANAFI" : "STANDARD")
+
   readonly property string tooltipLabel: nextPrayer
     ? (location ? location + " · " : "") + nextPrayer.name + " in " + Model.timeRemaining(nextPrayer, nowTick) + " (" + Model.formatTime12(nextPrayer.time) + ")"
     : "Prayer times"
@@ -80,8 +98,21 @@ BarWidget {
   // default mark is already right.
   readonly property real openPanelIndicatorWidth: countdownVisible ? content.implicitWidth : 0
 
+  // prayer-fetch.sh is told which Asr to ask for on the command line, so the
+  // first fetch has to wait for the preference file: firing before it is read
+  // would pull Standard times and visibly correct them a moment later.
   function refresh() {
-    if (!fetchProc.running) fetchProc.running = true
+    if (!root.settingsLoaded || fetchProc.running) {
+      root.refetchQueued = true
+      return
+    }
+    root.refetchQueued = false
+    fetchProc.running = true
+  }
+
+  function markSettingsReady() {
+    root.settingsLoaded = true
+    if (root.refetchQueued) Qt.callLater(root.refresh)
   }
 
   // Contract PopupCard expects on its `owner`: when the focus-grab dismisses
@@ -161,20 +192,22 @@ BarWidget {
     root.alertsEnabled = settings.alerts
     root.soundEnabled = settings.sound
     root.showCountdown = settings.countdown
-    root.settingsLoaded = true
+    root.hanafiAsr = settings.hanafiAsr
+    root.markSettingsReady()
   }
 
   function saveSettings() {
     // The file loads asynchronously; marking it loaded here keeps a toggle
     // made in that first moment from being overwritten by the load that
     // lands after it.
-    root.settingsLoaded = true
     settingsFile.setText(JSON.stringify({
-      version: 3,
+      version: 4,
       alerts: root.alertsEnabled,
       sound: root.soundEnabled,
-      countdown: root.showCountdown
+      countdown: root.showCountdown,
+      hanafiAsr: root.hanafiAsr
     }, null, 2) + "\n")
+    root.markSettingsReady()
   }
 
   // Normal urgency: the shell floors it at 8s and gives it the regular
@@ -213,6 +246,7 @@ BarWidget {
     root.timings = data.timings || null
     root.location = data.location || ""
     root.hijri = data.hijri || ""
+    root.cachedSchool = data.school || ""
     root.lastError = ""
   }
 
@@ -241,11 +275,14 @@ BarWidget {
 
   Process {
     id: fetchProc
-    command: ["bash", root.scriptPath]
+    command: ["bash", root.scriptPath, Model.asrArg(root.hanafiAsr)]
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: root.applyData(Model.parseCache(text))
     }
+    // A toggle flipped mid-fetch would otherwise be dropped, leaving the
+    // popup on the school the in-flight run had already asked for.
+    onExited: if (root.refetchQueued) Qt.callLater(root.refresh)
   }
 
   Process { id: notifyProc }
@@ -574,11 +611,41 @@ BarWidget {
           }
         }
 
+        // Only after a re-fetch has failed: the times above are still the
+        // other madhhab's, and Asr is the one that differs.
+        Text {
+          visible: root.asrOutOfDate
+          text: "Still showing " + (root.cachedSchool === "HANAFI" ? "Hanafi" : "standard")
+            + " Asr — right-click the icon to retry"
+          color: root.bar.urgent
+          font.family: root.bar.fontFamily
+          font.pixelSize: Style.font.caption
+          wrapMode: Text.WordWrap
+          width: parent.width
+        }
+
         Rectangle {
           width: parent.width
           height: Style.spacing.hairline
           color: root.bar.foreground
           opacity: 0.12
+        }
+
+        // Above the alert switches because this one changes the times
+        // themselves, not just how they are announced.
+        Toggle {
+          width: parent.width
+          label: "Hanafi Asr"
+          description: root.hanafiAsr ? "Shadow twice the object" : "Standard — shadow equal to the object"
+          checked: root.hanafiAsr
+          foreground: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+          titleSize: Style.font.bodySmall
+          onClicked: {
+            root.hanafiAsr = !root.hanafiAsr
+            root.saveSettings()
+            root.refresh()
+          }
         }
 
         Toggle {

--- a/Model.js
+++ b/Model.js
@@ -57,23 +57,34 @@ function prayerKey(prayer) {
   return d.getFullYear() + "-" + (d.getMonth() + 1) + "-" + d.getDate() + " " + prayer.name
 }
 
-// Widget preference file -> { alerts, sound, countdown }. Anything missing or
-// corrupt reads as its default, so a first run (or a file we can't parse) still
-// alerts. Older files carry fewer keys -- v1 has no `sound`, v2 no `countdown`
-// -- and each falls through.
+// Widget preference file -> { alerts, sound, countdown, hanafiAsr }. Anything
+// missing or corrupt reads as its default, so a first run (or a file we can't
+// parse) still alerts. Older files carry fewer keys -- v1 has no `sound`, v2 no
+// `countdown`, v3 no `hanafiAsr` -- and each falls through to its default.
 //
 // countdown defaults to false: the widget is built to sit among the wifi/sound
 // icons, so the bar label is something the user asks for rather than something
 // an upgrade springs on them.
+//
+// hanafiAsr defaults to false (Standard) because that is what Aladhan returns
+// when the caller says nothing, so an existing cache stays consistent with the
+// preference until the user says otherwise.
 function parseSettings(raw) {
-  var out = { alerts: true, sound: true, countdown: false }
+  var out = { alerts: true, sound: true, countdown: false, hanafiAsr: false }
   try {
     var data = JSON.parse(String(raw || "{}"))
     if (data && typeof data.alerts === "boolean") out.alerts = data.alerts
     if (data && typeof data.sound === "boolean") out.sound = data.sound
     if (data && typeof data.countdown === "boolean") out.countdown = data.countdown
+    if (data && typeof data.hanafiAsr === "boolean") out.hanafiAsr = data.hanafiAsr
   } catch (e) {}
   return out
+}
+
+// The argument prayer-fetch.sh expects for a madhhab. Kept here so the widget
+// and the tests agree on the spelling the script parses.
+function asrArg(hanafiAsr) {
+  return hanafiAsr ? "hanafi" : "standard"
 }
 
 // "HH:MM" (24h, as returned by the API) -> "h:MM AM/PM" for display.
@@ -162,6 +173,7 @@ if (typeof module !== "undefined") {
     duePrayer: duePrayer,
     prayerKey: prayerKey,
     parseSettings: parseSettings,
+    asrArg: asrArg,
     formatTime12: formatTime12,
     timeRemaining: timeRemaining,
     minutesRemaining: minutesRemaining,

--- a/Model.js
+++ b/Model.js
@@ -57,15 +57,21 @@ function prayerKey(prayer) {
   return d.getFullYear() + "-" + (d.getMonth() + 1) + "-" + d.getDate() + " " + prayer.name
 }
 
-// Alerts preference file -> { alerts, sound }. Anything missing or corrupt
-// reads as enabled, so a first run (or a file we can't parse) still alerts.
-// v1 files carry no `sound` key; they fall through to the default.
+// Widget preference file -> { alerts, sound, countdown }. Anything missing or
+// corrupt reads as its default, so a first run (or a file we can't parse) still
+// alerts. Older files carry fewer keys -- v1 has no `sound`, v2 no `countdown`
+// -- and each falls through.
+//
+// countdown defaults to false: the widget is built to sit among the wifi/sound
+// icons, so the bar label is something the user asks for rather than something
+// an upgrade springs on them.
 function parseSettings(raw) {
-  var out = { alerts: true, sound: true }
+  var out = { alerts: true, sound: true, countdown: false }
   try {
     var data = JSON.parse(String(raw || "{}"))
     if (data && typeof data.alerts === "boolean") out.alerts = data.alerts
     if (data && typeof data.sound === "boolean") out.sound = data.sound
+    if (data && typeof data.countdown === "boolean") out.countdown = data.countdown
   } catch (e) {}
   return out
 }
@@ -92,6 +98,16 @@ function timeRemaining(next, now) {
   var h = Math.floor(totalMin / 60)
   var m = totalMin % 60
   return h > 0 ? (h + "h " + m + "m") : (m + "m")
+}
+
+// Whole minutes until `next`, or -1 when there is nothing to count down to.
+// Rounded the same way as timeRemaining, so the bar label cannot read "10m"
+// while a threshold checked against this still believes there are 11 left.
+function minutesRemaining(next, now) {
+  if (!next || !next.date) return -1
+  var diffMs = next.date.getTime() - now.getTime()
+  if (diffMs <= 0) return 0
+  return Math.round(diffMs / 60000)
 }
 
 function countdownLabel(next, now) {
@@ -148,6 +164,7 @@ if (typeof module !== "undefined") {
     parseSettings: parseSettings,
     formatTime12: formatTime12,
     timeRemaining: timeRemaining,
+    minutesRemaining: minutesRemaining,
     countdownLabel: countdownLabel,
     parseGeocodingResults: parseGeocodingResults,
     locationCommit: locationCommit

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ until it restarts.
   seconds. It polls every 10 seconds and notifies each prayer at most once per
   day, and it won't replay a prayer that already passed before the shell
   started. The **Alerts** and **Sound** toggles at the bottom of the popup
-  turn them off; both are stored in
-  `~/.local/state/omarchy/settings/prayer-alerts.json` (separate from the
-  cached times, which `prayer-fetch.sh` rewrites wholesale).
+  turn them off, and **Hanafi Asr** picks the madhhab (below). They are stored
+  in `~/.local/state/omarchy/settings/prayer-alerts.json` with the other
+  preferences (separate from the cached times, which `prayer-fetch.sh` rewrites
+  wholesale).
 
 ## Configuration
 
@@ -79,6 +80,29 @@ bar** toggle at the bottom of the popup paints it next to the icon
 It takes the bar's urgent colour with 10 minutes or less to go — the same
 accent the popup gives the next prayer — and it is left out on a vertical bar,
 where there is no room for it; the tooltip still has it there.
+
+### Asr and the madhhab
+
+The **Hanafi Asr** toggle in the popup switches how Asr is calculated. The
+standard opinion (Shafi'i, Maliki, Hanbali) starts Asr once an object's shadow
+equals its own length; the Hanafi one waits for twice that, which puts Asr
+roughly an hour later. Nothing else in the timetable moves.
+
+The times are recomputed by the API rather than shifted locally, so flipping
+the toggle re-fetches — it needs a network round trip, and the popup says so in
+red if that fetch failed and the listed Asr is still the other school's.
+Right/middle-click the icon to retry.
+
+The preference lives in `prayer-alerts.json` as `"hanafiAsr": true|false`.
+`prayer-fetch.sh` reads it on a bare run, but the widget also passes the
+madhhab as the first argument (`hanafi` / `standard`) so a fetch fired the
+instant the toggle flips can't race the settings write. `PRAYER_SCHOOL=0|1`
+overrides the file for a one-off run, matching Aladhan's `school` parameter.
+
+```
+./prayer-fetch.sh hanafi     # force Hanafi, ignore the saved preference
+./prayer-fetch.sh            # use the saved preference (default: standard)
+```
 
 ### Calculation method
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ until it restarts.
 
 ## Configuration
 
+### Countdown in the bar
+
+Off by default — the icon is meant to sit among the built-in wifi/sound icons,
+and a label changes how much of the bar the widget claims. The **Countdown in
+bar** toggle at the bottom of the popup paints it next to the icon
+(`󰚁 Asr 1h 4m`) instead of only on hover, and is stored in
+`prayer-alerts.json` with the other preferences.
+
+It takes the bar's urgent colour with 10 minutes or less to go — the same
+accent the popup gives the next prayer — and it is left out on a vertical bar,
+where there is no room for it; the tooltip still has it there.
+
+### Calculation method
+
 Calculation method defaults to Muslim World League (Aladhan method `3`).
 Change it by editing `METHOD` in `prayer-fetch.sh`, or override per-run with
 `PRAYER_METHOD=<id>`. See the

--- a/prayer-fetch.sh
+++ b/prayer-fetch.sh
@@ -9,9 +9,35 @@ set -uo pipefail
 STATE_DIR="$HOME/.local/state/omarchy/settings"
 WEATHER_LOC="$STATE_DIR/weather.json"
 CACHE_FILE="$STATE_DIR/prayer-times.json"
+SETTINGS_FILE="$STATE_DIR/prayer-alerts.json"
 METHOD="${PRAYER_METHOD:-3}" # 3 = Muslim World League
 
 mkdir -p "$STATE_DIR"
+
+# Which madhhab sets Asr. Aladhan calls it `school`: 0 = Standard (Shafi'i,
+# Maliki, Hanbali -- Asr once an object's shadow equals its own length), 1 =
+# Hanafi (twice its length, which puts Asr roughly an hour later). Everything
+# else in the timetable is identical between the two.
+#
+# The widget passes its toggle in as $1 so a fetch fired the instant the
+# toggle flips cannot race the settings-file write. A bare run -- cron, a
+# terminal, the right-click refresh -- has no argument and falls back to the
+# stored preference.
+case "${1:-}" in
+hanafi) SCHOOL=1 ;;
+standard) SCHOOL=0 ;;
+"") SCHOOL="${PRAYER_SCHOOL:-}" ;;
+*)
+  echo "prayer-fetch: unknown madhhab '$1' (want 'hanafi' or 'standard')" >&2
+  exit 2
+  ;;
+esac
+
+if [[ -z $SCHOOL && -f $SETTINGS_FILE ]]; then
+  SCHOOL=$(jq -r 'if .hanafiAsr == true then 1 else 0 end' "$SETTINGS_FILE" 2>/dev/null)
+fi
+
+[[ $SCHOOL == 1 ]] || SCHOOL=0
 
 name="" lat="" lon=""
 
@@ -42,7 +68,7 @@ fi
 response=$(curl -fsS --max-time 8 -G \
   --data-urlencode "latitude=$lat" \
   --data-urlencode "longitude=$lon" \
-  --data "method=$METHOD" \
+  --data "method=$METHOD&school=$SCHOOL" \
   "https://api.aladhan.com/v1/timings/$(date +%d-%m-%Y)" 2>/dev/null)
 
 if [[ -z $response ]]; then
@@ -55,6 +81,7 @@ parsed=$(jq --arg name "${name:-Current location}" '
     location: $name,
     date: .data.date.readable,
     hijri: (.data.date.hijri.day + " " + .data.date.hijri.month.en + " " + .data.date.hijri.year + "H"),
+    school: (.data.meta.school // ""),
     timings: {
       Fajr: (.data.timings.Fajr | split(" ")[0]),
       Sunrise: (.data.timings.Sunrise | split(" ")[0]),


### PR DESCRIPTION
> **Stacked on #1** — that PR moved the countdown preference into `prayer-alerts.json`, so this one touches `parseSettings`/`saveSettings` and the popup's toggle column too. Branching off `master` would have handed you a conflict. GitHub therefore shows both commits here; **the second one, `Pick the madhhab that sets Asr`, is what this PR is about**. Merge #1 first and this collapses to that single commit. Happy to rebase it onto `master` standalone if you would rather take this one first — say the word and I will flip them.

Aladhan calls it `school`. The standard opinion (Shafi'i, Maliki, Hanbali) starts Asr once an object's shadow equals its own length; the Hanafi one waits for twice that, which puts Asr **roughly an hour later**. Nothing else in the timetable moves.

Right now the widget always takes whatever Aladhan returns by default — the standard one — with no way to ask for the other. For Hanafi users that means every Asr time in the popup, and every arrival alert, is about an hour early. This adds a **Hanafi Asr** toggle, above the alert switches because it changes the times themselves rather than how they are announced.

### The awkward part

The timetable is recomputed server-side, so flipping the toggle has to re-fetch rather than shift the cached time locally. Three things fall out of that, and they are most of the diff:

- **The first fetch now waits for the preference file.** Firing before it is read would pull standard times and visibly correct them a moment later, so `refresh()` queues until `markSettingsReady()` drains it.
- **The madhhab is passed to `prayer-fetch.sh` as `$1`** rather than letting the script read the file, so a fetch fired the instant the toggle flips cannot race the settings write. A toggle flipped while a fetch is already in flight re-queues on exit. A bare run — cron, a terminal, the right-click refresh — still falls back to the stored preference, and `PRAYER_SCHOOL=0|1` overrides for a one-off.
- **A re-fetch can fail** (offline, API down), which would leave the popup quietly listing the other school's Asr. The script echoes the school Aladhan actually used into the cache, and the popup says so in red when that disagrees with the toggle, pointing at right-click to retry.

### Checks

`omarchy plugin validate`, `qmllint -I $OMARCHY_PATH/shell` and `bash -n` all clean. `parseSettings` exercised at v1/v2/v3/v4/empty/corrupt — older files fall through to `hanafiAsr: false`, which is what Aladhan returns when the caller says nothing, so an existing cache stays consistent with the preference until the user changes it. `prayer-fetch.sh` rejects an unknown madhhab with exit 2 rather than silently fetching the wrong school. Running on a live bar against a Hanafi timetable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
